### PR TITLE
Add support for libreoffice

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -20,7 +20,8 @@ global convertor, oobin, oobinpath, oolibpath, ooproc
 
 ### The first thing we ought to do is find a suitable OpenOffice installation
 ### with a compatible pyuno library that we can import.
-extrapaths = glob.glob('/usr/lib*/openoffice*/program') + \
+extrapaths = glob.glob('/usr/lib*/libreoffice*/basis*/program') + \
+             glob.glob('/usr/lib*/openoffice*/program') + \
              glob.glob('/usr/lib*/openoffice*/basis*/program') + \
              glob.glob('/usr/lib*/ooo*/program') + \
              glob.glob('/usr/lib*/ooo*/basis*/program') + \


### PR DESCRIPTION
It looks like several, if not all, distributions are switching to libreoffice, from openoffice. Unfortunately this means that the search paths are going to be different. The attached commit fixed things for me, but it probably makes sense to change this in a more comprehensive way.

Other than the path unoconv seems to work fine with libreoffice 3.3.1.
