### PR TITLE
int values in export filters

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -379,7 +379,10 @@ class Options:
                     elif value in ('False', 'false'):
                         self.exportfilter.append( PropertyValue( name, 0, False, 0 ) )
                     else:
-                        self.exportfilter.append( PropertyValue( name, 0, value, 0 ) )
+                        try:
+                            self.exportfilter.append( PropertyValue( name, 0, int(value), 0 ) )
+                        except ValueError:
+                            self.exportfilter.append( PropertyValue( name, 0, value, 0 ) )
                 else:
                     print >>sys.stderr, 'Warning: Option %s cannot be parsed, ignoring.' % arg
             elif opt in ['-f', '--format']:


### PR DESCRIPTION
Hi Dag, 

Thanks for providing this script! I spotted that ints were not being respected in export filters so wrote this quick fix. It does what I want but don't know if it may cause knock-on effects with some other filters (I'm new to this open office stuff). 

e.g. ./unoconv -e Format=2 -f html whatever.ppt
creates PNG files with the fix or JPG files without (0 should be GIF, 1 JPG and 2 PNG)

Not sure what the etiquette here is so if you'd rather I created an issue against your repo, please let me know. Feel free to ignore! 

Thanks,
Steven. 
