### PR TITLE
Missing DocTypes

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -21,7 +21,7 @@ __version__ = "$Revision$"
 
 VERSION = '0.5'
 
-doctypes = ('document', 'graphics', 'presentation', 'spreadsheet')
+doctypes = ('document', 'web', 'global', 'spreadsheet', 'graphics', 'presentation', 'formula', 'database')
 
 global convertor, office, ooproc
 ooproc = None
@@ -173,8 +173,8 @@ def office_environ(office):
         for libpath in os.path.join(office.pythonhome, 'lib') + \
                        os.path.join(office.pythonhome, 'lib', 'lib-dynload') + \
                        os.path.join(office.pythonhome, 'lib', 'lib-tk') + \
-                       os.path.join(office.pythonhome, 'lib', 'site-packages') +\
-                       office.unopath):
+                       os.path.join(office.pythonhome, 'lib', 'site-packages') + \
+                       office.unopath:
             sys.path.insert(0, libpath)
 
 def debug_office():
@@ -302,6 +302,7 @@ fmts.add('document', 'doc95', 'doc', 'Microsoft Word 95', 'MS Word 95') ### 28
 fmts.add('document', 'docbook', 'xml', 'DocBook', 'DocBook File') ### 39
 fmts.add('document', 'fodt', 'fodt', 'OpenDocument Text (Flat XML)', 'OpenDocument Text Flat XML')
 fmts.add('document', 'html', 'html', 'HTML Document (OpenOffice.org Writer)', 'HTML (StarWriter)') ### 3
+fmts.add('document', 'html', 'htm', 'HTML Document (OpenOffice.org Writer)', 'HTML (StarWriter)') ### 3
 fmts.add('document', 'odt', 'odt', 'ODF Text Document', 'writer8') ### 10
 fmts.add('document', 'ott', 'ott', 'Open Document Text', 'writer8_template') ### 21
 fmts.add('document', 'ooxml', 'xml', 'Microsoft Office Open XML', 'MS Word 2003 XML') ### 11
@@ -325,9 +326,14 @@ fmts.add('document', 'vor', 'vor', 'StarWriter 5.0 Template', 'StarWriter 5.0 Vo
 fmts.add('document', 'vor4', 'vor', 'StarWriter 4.0 Template', 'StarWriter 4.0 Vorlage/Template') ### 5
 fmts.add('document', 'vor3', 'vor', 'StarWriter 3.0 Template', 'StarWriter 3.0 Vorlage/Template') ### 4
 fmts.add('document', 'xhtml', 'html', 'XHTML Document', 'XHTML Writer File') ### 33
+fmts.add('document', 'xhtml', 'htm', 'XHTML Document', 'XHTML Writer File') ### 33
+fmts.add('document', 'xhtml', 'xht', 'XHTML Document', 'XHTML Writer File') ### 33
+fmts.add('document', 'xhtml', 'xhtml', 'XHTML Document', 'XHTML Writer File') ### 33
+fmts.add('document', 'xhtml', 'xml', 'XHTML Document', 'XHTML Writer File') ### 33
 
 ### WebDocument
 fmts.add('web', 'html', 'html', 'HTML Document', 'HTML') ### 2
+fmts.add('web', 'html', 'htm', 'HTML Document', 'HTML') ### 2
 fmts.add('web', 'sdw3', 'sdw', 'StarWriter 3.0 (OpenOffice.org Writer/Web)', 'StarWriter 3.0 (StarWriter/Web)') ### 3
 fmts.add('web', 'sdw4', 'sdw', 'StarWriter 4.0 (OpenOffice.org Writer/Web)', 'StarWriter 4.0 (StarWriter/Web)') ### 4
 fmts.add('web', 'sdw', 'sdw', 'StarWriter 5.0 (OpenOffice.org Writer/Web)', 'StarWriter 5.0 (StarWriter/Web)') ### 5
@@ -338,16 +344,32 @@ fmts.add('web', 'mediawiki', 'txt', 'MediaWiki', 'MediaWiki_Web') ### 9
 fmts.add('web', 'pdf', 'pdf', 'PDF - Portable Document Format', 'writer_web_pdf_Export') ### 10
 fmts.add('web', 'html10', 'html', 'OpenOffice.org 1.0 HTML Template', 'writer_web_StarOffice_XML_Writer_Web_Template') ### 11
 fmts.add('web', 'txt', 'txt', 'OpenOffice.org Text (OpenOffice.org Writer/Web)', 'writerweb8_writer') ### 12
-fmts.add('web', 'html', 'html', 'HTML Document Template', 'writerweb8_writer_template') ### 13
+fmts.add('web', 'htmlt', 'html', 'HTML Document Template', 'writerweb8_writer_template') ### 13
 fmts.add('web', 'etext', 'txt', 'Text Encoded (OpenOffice.org Writer/Web)', 'Text (encoded) (StarWriter/Web)') ### 14
 fmts.add('web', 'text10', 'txt', 'OpenOffice.org 1.0 Text Document (OpenOffice.org Writer/Web)', 'writer_web_StarOffice_XML_Writer') ### 15
 
-### Spreadsheet
+### GlobalDocument
+#fmts.add('global', '', '', 'StarWriter 3.0', 'StarWriter 3.0 (StarWriter/GlobalDocument)') ### 3
+#fmts.add('global', '', '', 'StarWriter 4.0', 'StarWriter 4.0 (StarWriter/GlobalDocument)') ### 4
+#fmts.add('global', '', '', 'ODF Master Document', 'writerglobal8') ### 7
+#fmts.add('global', '', '', 'StarWriter 4.0 Master Document', 'StarWriter 4.0/GlobalDocument') ### 9
+#fmts.add('global', '', '', 'StarWriter 5.0 Master Document', 'StarWriter 5.0/GlobalDocument') ### 10
+fmts.add('global', 'html', 'htm', 'HTML (Writer/Global)', 'writerglobal8_HTML') ### 6
+fmts.add('global', 'html', 'html', 'HTML (Writer/Global)', 'writerglobal8_HTML') ### 6
+fmts.add('global', 'odt', 'odt', 'ODF Text Document', 'writerglobal8_writer') ### 8
+fmts.add('global', 'pdf', 'pdf', 'PDF - Portable Document Format', 'writer_globaldocument_pdf_Export') ### 11
+fmts.add('global', 'sgl', 'sgl', 'StarWriter 5.0', 'StarWriter 5.0 (StarWriter/GlobalDocument)') ### 5
+fmts.add('global', 'sxg', 'sxg', 'OpenOffice.org 1.0 Master Document', 'writer_globaldocument_StarOffice_XML_Writer_GlobalDocument') ### 1
+fmts.add('global', 'sxw', 'sxw', 'OpenOffice.org 1.0 Text Document', 'writer_globaldocument_StarOffice_XML_Writer') ### 12
+fmts.add('global', 'txt', 'txt', 'Text Encoded (OpenOffice.org Master Document)', 'Text (encoded) (StarWriter/GlobalDocument)') ### 2
+
+### SpreadsheetDocument
 fmts.add('spreadsheet', 'csv', 'csv', 'Text CSV', 'Text - txt - csv (StarCalc)') ### 16
 fmts.add('spreadsheet', 'dbf', 'dbf', 'dBASE', 'dBase') ### 22
 fmts.add('spreadsheet', 'dif', 'dif', 'Data Interchange Format', 'DIF') ### 5
 fmts.add('spreadsheet', 'fods', 'fods', 'OpenDocument Spreadsheet (Flat XML)', 'OpenDocument Spreadsheet Flat XML')
 fmts.add('spreadsheet', 'html', 'html', 'HTML Document (OpenOffice.org Calc)', 'HTML (StarCalc)') ### 7
+fmts.add('spreadsheet', 'html', 'htm', 'HTML Document (OpenOffice.org Calc)', 'HTML (StarCalc)') ### 7
 fmts.add('spreadsheet', 'ods', 'ods', 'ODF Spreadsheet', 'calc8') ### 15
 fmts.add('spreadsheet', 'ooxml', 'xml', 'Microsoft Excel 2003 XML', 'MS Excel 2003 XML') ### 23
 fmts.add('spreadsheet', 'ots', 'ots', 'ODF Spreadsheet Template', 'calc8_template') ### 14
@@ -363,7 +385,11 @@ fmts.add('spreadsheet', 'uos', 'uos', 'Unified Office Format spreadsheet', 'UOF 
 fmts.add('spreadsheet', 'vor3', 'vor', 'StarCalc 3.0 Template', 'StarCalc 3.0 Vorlage/Template') ### 18
 fmts.add('spreadsheet', 'vor4', 'vor', 'StarCalc 4.0 Template', 'StarCalc 4.0 Vorlage/Template') ### 19
 fmts.add('spreadsheet', 'vor', 'vor', 'StarCalc 5.0 Template', 'StarCalc 5.0 Vorlage/Template') ### 20
+fmts.add('spreadsheet', 'xhtml', 'html', 'XHTML', 'XHTML Calc File') ### 26
+fmts.add('spreadsheet', 'xhtml', 'htm', 'XHTML', 'XHTML Calc File') ### 26
+fmts.add('spreadsheet', 'xhtml', 'xht', 'XHTML', 'XHTML Calc File') ### 26
 fmts.add('spreadsheet', 'xhtml', 'xhtml', 'XHTML', 'XHTML Calc File') ### 26
+fmts.add('spreadsheet', 'xhtml', 'xml', 'XHTML', 'XHTML Calc File') ### 26
 fmts.add('spreadsheet', 'xls', 'xls', 'Microsoft Excel 97/2000/XP', 'MS Excel 97') ### 12
 fmts.add('spreadsheet', 'xls5', 'xls', 'Microsoft Excel 5.0', 'MS Excel 5.0/95') ### 8
 fmts.add('spreadsheet', 'xls95', 'xls', 'Microsoft Excel 95', 'MS Excel 95') ### 10
@@ -371,13 +397,14 @@ fmts.add('spreadsheet', 'xlt', 'xlt', 'Microsoft Excel 97/2000/XP Template', 'MS
 fmts.add('spreadsheet', 'xlt5', 'xlt', 'Microsoft Excel 5.0 Template', 'MS Excel 5.0/95 Vorlage/Template') ### 28
 fmts.add('spreadsheet', 'xlt95', 'xlt', 'Microsoft Excel 95 Template', 'MS Excel 95 Vorlage/Template') ### 21
 
-### Graphics
+### DrawingDocument
 fmts.add('graphics', 'bmp', 'bmp', 'Windows Bitmap', 'draw_bmp_Export') ### 21
 fmts.add('graphics', 'emf', 'emf', 'Enhanced Metafile', 'draw_emf_Export') ### 15
 fmts.add('graphics', 'eps', 'eps', 'Encapsulated PostScript', 'draw_eps_Export') ### 48
 fmts.add('graphics', 'fodg', 'fodg', 'OpenDocument Drawing (Flat XML)', 'OpenDocument Drawing Flat XML')
 fmts.add('graphics', 'gif', 'gif', 'Graphics Interchange Format', 'draw_gif_Export') ### 30
 fmts.add('graphics', 'html', 'html', 'HTML Document (OpenOffice.org Draw)', 'draw_html_Export') ### 37
+fmts.add('graphics', 'html', 'htm', 'HTML Document (OpenOffice.org Draw)', 'draw_html_Export') ### 37
 fmts.add('graphics', 'jpg', 'jpg', 'Joint Photographic Experts Group', 'draw_jpg_Export') ### 3
 fmts.add('graphics', 'met', 'met', 'OS/2 Metafile', 'draw_met_Export') ### 43
 fmts.add('graphics', 'odd', 'odd', 'OpenDocument Drawing', 'draw8') ### 6
@@ -401,16 +428,21 @@ fmts.add('graphics', 'tiff', 'tiff', 'Tagged Image File Format', 'draw_tif_Expor
 fmts.add('graphics', 'vor', 'vor', 'StarDraw 5.0 Template', 'StarDraw 5.0 Vorlage') ### 36
 fmts.add('graphics', 'vor3', 'vor', 'StarDraw 3.0 Template', 'StarDraw 3.0 Vorlage') ### 35
 fmts.add('graphics', 'wmf', 'wmf', 'Windows Metafile', 'draw_wmf_Export') ### 8
+fmts.add('graphics', 'xhtml', 'html', 'XHTML', 'XHTML Draw File') ### 45
+fmts.add('graphics', 'xhtml', 'htm', 'XHTML', 'XHTML Draw File') ### 45
+fmts.add('graphics', 'xhtml', 'xht', 'XHTML', 'XHTML Draw File') ### 45
 fmts.add('graphics', 'xhtml', 'xhtml', 'XHTML', 'XHTML Draw File') ### 45
+fmts.add('graphics', 'xhtml', 'xml', 'XHTML', 'XHTML Draw File') ### 45
 fmts.add('graphics', 'xpm', 'xpm', 'X PixMap', 'draw_xpm_Export') ### 19
 
-### Presentation
+### PresentationDocument
 fmts.add('presentation', 'bmp', 'bmp', 'Windows Bitmap', 'impress_bmp_Export') ### 15
 fmts.add('presentation', 'emf', 'emf', 'Enhanced Metafile', 'impress_emf_Export') ### 16
 fmts.add('presentation', 'eps', 'eps', 'Encapsulated PostScript', 'impress_eps_Export') ### 17
 fmts.add('presentation', 'fodp', 'fodp', 'OpenDocument Presentation (Flat XML)', 'OpenDocument Presentation Flat XML')
 fmts.add('presentation', 'gif', 'gif', 'Graphics Interchange Format', 'impress_gif_Export') ### 18
 fmts.add('presentation', 'html', 'html', 'HTML Document (OpenOffice.org Impress)', 'impress_html_Export') ### 43
+fmts.add('presentation', 'html', 'htm', 'HTML Document (OpenOffice.org Impress)', 'impress_html_Export') ### 43
 fmts.add('presentation', 'jpg', 'jpg', 'Joint Photographic Experts Group', 'impress_jpg_Export') ### 19
 fmts.add('presentation', 'met', 'met', 'OS/2 Metafile', 'impress_met_Export') ### 20
 fmts.add('presentation', 'odg', 'odg', 'ODF Drawing (Impress)', 'impress8_draw') ### 29
@@ -446,8 +478,23 @@ fmts.add('presentation', 'vor3', 'vor', 'StarDraw 3.0 Template (OpenOffice.org I
 fmts.add('presentation', 'vor4', 'vor', 'StarImpress 4.0 Template', 'StarImpress 4.0 Vorlage') ### 39
 fmts.add('presentation', 'vor5', 'vor', 'StarDraw 5.0 Template (OpenOffice.org Impress)', 'StarDraw 5.0 Vorlage (StarImpress)') ### 2
 fmts.add('presentation', 'wmf', 'wmf', 'Windows Metafile', 'impress_wmf_Export') ### 11
+fmts.add('presentation', 'xhtml', 'html', 'XHTML', 'XHTML Impress File') ### 33
+fmts.add('presentation', 'xhtml', 'htm', 'XHTML', 'XHTML Impress File') ### 33
+fmts.add('presentation', 'xhtml', 'xht', 'XHTML', 'XHTML Impress File') ### 33
+fmts.add('presentation', 'xhtml', 'xhtml', 'XHTML', 'XHTML Impress File') ### 33
 fmts.add('presentation', 'xhtml', 'xml', 'XHTML', 'XHTML Impress File') ### 33
 fmts.add('presentation', 'xpm', 'xpm', 'X PixMap', 'impress_xpm_Export') ### 10
+
+### FormulaProperties
+#fmts.add('formula', '', '', 'MathType3.x', 'MathType 3.x') ### 4
+fmts.add('formula', 'mml', 'mml', 'MathML 1.01', 'MathML XML (Math)') ### 8
+fmts.add('formula', 'odf', 'odf', 'ODF Formula', 'math8') ### 9
+fmts.add('formula', 'pdf', 'pdf', 'PDF - Portable Document Format', 'math_pdf_Export') ### 7
+fmts.add('formula', 'smf', 'smf', 'StarMath 5.0', 'StarMath 5.0') ### 2
+fmts.add('formula', 'sxm', 'sxm', 'OpenOffice.org 1.0 Formula', 'StarOffice XML (Math)') ### 3
+
+### OfficeDatabaseDocument
+fmts.add('database', 'odb', 'odb', 'ODF Database', 'StarOffice XML (Base)') ### 1
 
 class Options:
     def __init__(self, args):
@@ -606,7 +653,8 @@ class Options:
 unoconv options:
   -c, --connection=string  use a custom connection string
   -d, --doctype=type       specify document type
-                             (document, graphics, presentation, spreadsheet)
+                             (document, web, global, spreadsheet,
+                              graphics, presentation, formula, database)
   -e, --export=name=value  set export filter options
                              eg. -e PageRange=1-2
   -f, --format=format      specify the output format

--- a/unoconv
+++ b/unoconv
@@ -351,11 +351,11 @@ fmts.add('web', 'text10', 'txt', 'OpenOffice.org 1.0 Text Document (OpenOffice.o
 ### GlobalDocument
 #fmts.add('global', '', '', 'StarWriter 3.0', 'StarWriter 3.0 (StarWriter/GlobalDocument)') ### 3
 #fmts.add('global', '', '', 'StarWriter 4.0', 'StarWriter 4.0 (StarWriter/GlobalDocument)') ### 4
-#fmts.add('global', '', '', 'ODF Master Document', 'writerglobal8') ### 7
 #fmts.add('global', '', '', 'StarWriter 4.0 Master Document', 'StarWriter 4.0/GlobalDocument') ### 9
 #fmts.add('global', '', '', 'StarWriter 5.0 Master Document', 'StarWriter 5.0/GlobalDocument') ### 10
 fmts.add('global', 'html', 'htm', 'HTML (Writer/Global)', 'writerglobal8_HTML') ### 6
 fmts.add('global', 'html', 'html', 'HTML (Writer/Global)', 'writerglobal8_HTML') ### 6
+fmts.add('global', 'odm', 'odm', 'ODF Master Document', 'writerglobal8') ### 7
 fmts.add('global', 'odt', 'odt', 'ODF Text Document', 'writerglobal8_writer') ### 8
 fmts.add('global', 'pdf', 'pdf', 'PDF - Portable Document Format', 'writer_globaldocument_pdf_Export') ### 11
 fmts.add('global', 'sgl', 'sgl', 'StarWriter 5.0', 'StarWriter 5.0 (StarWriter/GlobalDocument)') ### 5


### PR DESCRIPTION
Added missing doctypes and file extensions.

Set "html" as default file extension for "html" and "xhtml".

Removed doubled "html" filter name. HTML Web Document Template is now called "htmlt".
