### PR TITLE
Random seg.faults in unoconv

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -1005,6 +1005,10 @@ def die(ret, str=None):
             info(3, 'Waiting for %s with pid %s to disappear.' % (ooproc.pid, product.ooName))
             ooproc.wait()
 
+    # allow Python GC to garbage collect pyuno object *before* exit call
+    # which avoids random segmentation faults --vpa
+    convertor = None
+
     sys.exit(ret)
 
 def main():


### PR DESCRIPTION
Dear Dag,

I debugged the "random seg. fault" problem which occured for me on Debian squeeze with openoffice (and libreoffice) after every execution of unoconv. Using gdb I found the crash is caused in pyuno.so when destroying pyuno objects and simultaneous terminate of the python interpreter (in sys.exit). 

The simpelst fix, is IMO to garbage collect the pyuno convertor object before calling sys.exit.

Hopefully this helps, regards
--Volker
