### PR TITLE
Endless recursion fix for windows...

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -1046,7 +1046,7 @@ if __name__ == '__main__':
     info(3, 'sysname=%s, platform=%s, python=%s, python-version=%s' % (os.name, sys.platform, sys.executable, sys.version))
 
     for of in find_offices():
-        if of.python != sys.executable and not sys.executable.startswith(of.unopath):
+        if of.python != sys.executable and not sys.executable.startswith(of.basepath):
             python_switch(of)
         office_environ(of)
 #        debug_office()


### PR DESCRIPTION
On Windows OpenOffice/LibreOffice are _two_ python binaries within the basepath:

 (1) C:\Program Files (x86)\OpenOffice.org 3\program\python.exe
 (2) C:\Program Files (x86)\OpenOffice.org 3\Basis\program\python-core-2.6.1\bin\python.exe

find_offices() always finds (1) as office python, while unopath is always set to
'C:\Program Files (x86)\OpenOffice.org 3\Basis\program'.

Thus "sys.executable.startswith(of._uno_path)" is always "False", which leads to an endless
(recursive) restart in python_switch() (at least on Windows). 

To fix this call only python_switch() as long no python binary from within _base_path
is executed.

--vpa
