### PR TITLE
Python path variable using env

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 ### This program is free software; you can redistribute it and/or modify
 ### it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
python not necessarily under /usr/bin
 (e.g. not in FreeBSD, here under /usr/local/bin).

/usr/bin/env makes it portable.

See https://github.com/dagwieers/unoconv/issues/57

Thanks
Peter
