### PR TITLE
 Fix Text Encoded filter definition

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -18,7 +18,6 @@ from distutils.version import LooseVersion
 import getopt
 import glob
 import os
-import socket
 import subprocess
 import sys
 import time
@@ -224,18 +223,18 @@ def office_environ(office):
 
 def debug_office():
     if 'URE_BOOTSTRAP' in os.environ:
-        print >>sys.stderr, 'URE_BOOTSTRAP=%s' % os.environ['URE_BOOTSTRAP']
+        print >> sys.stderr, 'URE_BOOTSTRAP=%s' % os.environ['URE_BOOTSTRAP']
     if 'UNO_PATH' in os.environ:
-        print >>sys.stderr, 'UNO_PATH=%s' % os.environ['UNO_PATH']
+        print >> sys.stderr, 'UNO_PATH=%s' % os.environ['UNO_PATH']
     if 'UNO_TYPES' in os.environ:
-        print >>sys.stderr, 'UNO_TYPES=%s' % os.environ['UNO_TYPES']
+        print >> sys.stderr, 'UNO_TYPES=%s' % os.environ['UNO_TYPES']
     print 'PATH=%s' % os.environ['PATH']
     if 'PYTHONHOME' in os.environ:
-        print >>sys.stderr, 'PYTHONHOME=%s' % os.environ['PYTHONHOME']
+        print >> sys.stderr, 'PYTHONHOME=%s' % os.environ['PYTHONHOME']
     if 'PYTHONPATH' in os.environ:
-        print >>sys.stderr, 'PYTHONPATH=%s' % os.environ['PYTHONPATH']
+        print >> sys.stderr, 'PYTHONPATH=%s' % os.environ['PYTHONPATH']
     if 'LD_LIBRARY_PATH' in os.environ:
-        print >>sys.stderr, 'LD_LIBRARY_PATH=%s' % os.environ['LD_LIBRARY_PATH']
+        print >> sys.stderr, 'LD_LIBRARY_PATH=%s' % os.environ['LD_LIBRARY_PATH']
 
 def python_switch(office):
     if office.pythonhome:
@@ -326,11 +325,11 @@ class FmtList:
         return ret
 
     def display(self, doctype):
-        print >>sys.stderr, "The following list of %s formats are currently available:\n" % doctype
+        print >> sys.stderr, "The following list of %s formats are currently available:\n" % doctype
         for fmt in self.list:
             if fmt.doctype == doctype:
-                print >>sys.stderr, "  %-8s - %s" % (fmt.name, fmt)
-        print >>sys.stderr
+                print >> sys.stderr, "  %-8s - %s" % (fmt.name, fmt)
+        print >> sys.stderr
 
 fmts = FmtList()
 
@@ -358,7 +357,7 @@ fmts.add('document', 'sdw4', 'sdw', 'StarWriter 4.0', 'StarWriter 4.0') ### 2
 fmts.add('document', 'sdw3', 'sdw', 'StarWriter 3.0', 'StarWriter 3.0') ### 20
 fmts.add('document', 'stw', 'stw', 'Open Office.org 1.0 Text Document Template', 'writer_StarOffice_XML_Writer_Template') ### 9
 fmts.add('document', 'sxw', 'sxw', 'Open Office.org 1.0 Text Document', 'StarOffice XML (Writer)') ### 1
-fmts.add('document', 'text', 'txt', 'Text Encoded', 'Text (Encoded)') ### 26
+fmts.add('document', 'text', 'txt', 'Text Encoded', 'Text (encoded)') ### 26
 fmts.add('document', 'txt', 'txt', 'Text', 'Text') ### 34
 fmts.add('document', 'uot', 'uot', 'Unified Office Format text','UOF text') ### 27
 fmts.add('document', 'vor', 'vor', 'StarWriter 5.0 Template', 'StarWriter 5.0 Vorlage/Template') ### 6
@@ -549,7 +548,7 @@ class Options:
                         except ValueError:
                             self.exportfilter.append( PropertyValue( name, 0, value, 0 ) )
                 else:
-                    print >>sys.stderr, 'Warning: Option %s cannot be parsed, ignoring.' % arg
+                    print >> sys.stderr, 'Warning: Option %s cannot be parsed, ignoring.' % arg
 #                    self.exportfilter = arg
             elif opt in ['-f', '--format']:
                 self.format = arg
@@ -562,7 +561,7 @@ class Options:
             elif opt in ['-o', '--output']:
                 self.output = arg
             elif opt in ['--outputpath']:
-                print >>sys.stderr, 'Warning: This option is deprecated by --output.'
+                print >> sys.stderr, 'Warning: This option is deprecated by --output.'
                 self.output = arg
             elif opt in ['--password']:
                 self.password = arg
@@ -588,13 +587,13 @@ class Options:
 
         ### Enable verbosity
         if self.verbose >= 2:
-            print >>sys.stderr, 'Verbosity set to level %d' % self.verbose
+            print >> sys.stderr, 'Verbosity set to level %d' % self.verbose
 
         self.filenames = args
 
         if not self.listener and not self.showlist and self.doctype != 'list' and not self.filenames:
-            print >>sys.stderr, 'unoconv: you have to provide a filename as argument'
-            print >>sys.stderr, 'Try `unoconv -h\' for more information.'
+            print >> sys.stderr, 'unoconv: you have to provide a filename as argument'
+            print >> sys.stderr, 'Try `unoconv -h\' for more information.'
             sys.exit(255)
 
         ### Set connection string
@@ -643,10 +642,10 @@ class Options:
         print 'build revision $Rev$'
 
     def usage(self):
-        print >>sys.stderr, 'usage: unoconv [options] file [file2 ..]'
+        print >> sys.stderr, 'usage: unoconv [options] file [file2 ..]'
 
     def help(self):
-        print >>sys.stderr, '''Convert from and to any format supported by LibreOffice
+        print >> sys.stderr, '''Convert from and to any format supported by LibreOffice
 
 unoconv options:
   -c, --connection=string  use a custom connection string
@@ -765,16 +764,16 @@ class Convertor:
                         break
                 else:
                     outputfmt = outputfmt[0]
-    #       print >>sys.stderr, 'unoconv: format `%s\' is part of multiple doctypes %s, selecting `%s\'.' % (format, [fmt.doctype for fmt in outputfmt], outputfmt[0].doctype)
+    #       print >> sys.stderr, 'unoconv: format `%s\' is part of multiple doctypes %s, selecting `%s\'.' % (format, [fmt.doctype for fmt in outputfmt], outputfmt[0].doctype)
             else:
                 outputfmt = outputfmt[0]
 
         ### No format found, throw error
         if not outputfmt:
             if doctype:
-                print >>sys.stderr, 'unoconv: format [%s/%s] is not known to unoconv.' % (op.doctype, op.format)
+                print >> sys.stderr, 'unoconv: format [%s/%s] is not known to unoconv.' % (op.doctype, op.format)
             else:
-                print >>sys.stderr, 'unoconv: format [%s] is not known to unoconv.' % op.format
+                print >> sys.stderr, 'unoconv: format [%s] is not known to unoconv.' % op.format
             die(1)
 
         return outputfmt
@@ -786,10 +785,10 @@ class Convertor:
         outputfmt = self.getformat(inputfn)
 
         if op.verbose > 0:
-            print >>sys.stderr, 'Input file:', inputfn
+            print >> sys.stderr, 'Input file:', inputfn
 
         if not os.path.exists(inputfn):
-            print >>sys.stderr, 'unoconv: file `%s\' does not exist.' % inputfn
+            print >> sys.stderr, 'unoconv: file `%s\' does not exist.' % inputfn
             exitcode = 1
 
         try:
@@ -818,7 +817,7 @@ class Convertor:
                     templateurl = unohelper.absolutize(self.cwd, unohelper.systemPathToFileUrl(op.template))
                     document.StyleFamilies.loadStylesFromURL(templateurl, templateprops)
                 else:
-                    print >>sys.stderr, 'unoconv: template file `%s\' does not exist.' % op.template
+                    print >> sys.stderr, 'unoconv: template file `%s\' does not exist.' % op.template
                     exitcode = 1
 
             ### Update document links
@@ -954,27 +953,27 @@ class Listener:
         else:
             info(1, "Existing %s listener found, nothing to do." % product.ooName)
 
-def error(str):
+def error(msg):
     "Output error message"
-    print >>sys.stderr, str
+    print >> sys.stderr, msg
 
-def info(level, str):
+def info(level, msg):
     "Output info message"
     if 'op' not in globals():
         pass
     elif op.verbose >= 3 and level >= 3:
-        print >>sys.stderr, "DEBUG:", str
+        print >> sys.stderr, "DEBUG:", msg
     elif not op.stdout and level <= op.verbose:
-        print >>sys.stdout, str
+        print >> sys.stdout, msg
     elif level <= op.verbose:
-        print >>sys.stderr, str
+        print >> sys.stderr, msg
 
-def die(ret, str=None):
+def die(ret, msg=None):
     "Print optional error and exit with errorcode"
     global convertor, ooproc, office
 
-    if str:
-        error('Error: %s' % str)
+    if msg:
+        error('Error: %s' % msg)
 
     ### Did we start our own listener instance ?
     if not op.listener and ooproc and convertor:
@@ -1068,14 +1067,14 @@ if __name__ == '__main__':
             break
         except:
 #            debug_office()
-            print >>sys.stderr, "unoconv: Cannot find a suitable pyuno library and python binary combination in %s" % of
-            print >>sys.stderr, "ERROR:", sys.exc_info()[1]
-            print >>sys.stderr
+            print >> sys.stderr, "unoconv: Cannot find a suitable pyuno library and python binary combination in %s" % of
+            print >> sys.stderr, "ERROR:", sys.exc_info()[1]
+            print >> sys.stderr
     else:
 #        debug_office()
-        print >>sys.stderr, "unoconv: Cannot find a suitable office installation on your system."
-        print >>sys.stderr, "ERROR: Please locate your office installation and send your feedback to:"
-        print >>sys.stderr, "       http://github.com/dagwieers/unoconv/issues"
+        print >> sys.stderr, "unoconv: Cannot find a suitable office installation on your system."
+        print >> sys.stderr, "ERROR: Please locate your office installation and send your feedback to:"
+        print >> sys.stderr, "       http://github.com/dagwieers/unoconv/issues"
         sys.exit(1)
 
     ### Now that we have found a working pyuno library, let's import some classes


### PR DESCRIPTION
- Fix typo in Text Encoded filter defintion.
- Improve code quality according to pylint by removing
  unused imports, avoiding redefining built-ins, and
  correcting spacing.
