### PR TITLE
Detect an unusable Home directory

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -21,8 +21,10 @@ import getopt
 import glob
 import os
 import signal
+import shutil
 import subprocess
 import sys
+import tempfile
 import time
 
 __version__ = '0.8.2'
@@ -717,6 +719,12 @@ class Options:
 
         self.filenames = args
 
+        # Check usability of invoking user's home directory
+        # (`os.path.expanduser()` takes into account the `HOME` environment value, if set.)
+        if not os.access(os.path.expanduser('~'), os.R_OK | os.W_OK):
+            print('unoconv: Home directory not usable (read/write). Using a temporary folder.', file=sys.stderr)
+            os.environ['HOME'] = tempfile.mkdtemp(prefix='unoconv.')
+
         if not self.listener and not self.showlist and not self.stdin and self.doctype != 'list' and not self.filenames:
             print('unoconv: you have to provide a filename or url as argument', file=sys.stderr)
             print('Try `unoconv -h\' for more information.', file=sys.stderr)
@@ -1331,6 +1339,10 @@ def die(ret, msg=None):
                 os.kill(ooproc.pid, 9)
             info(3, 'Waiting for %s with pid %s to disappear.' % (ooproc.pid, product.ooName))
             ooproc.wait()
+
+    # Check for and remove temporary HOME
+    if 'HOME' in os.environ and os.path.basename(os.environ['HOME']).startswith('unoconv.'):
+        shutil.rmtree(os.environ['HOME'])
 
     # Allow Python GC to garbage collect pyuno object *before* exit call
     # which avoids random segmentation faults --vpa


### PR DESCRIPTION
When Open/LibreOffice runs, it looks for a folder containing user-specific configuration in the invoking user's home directory. If it cannot find it, Open/LibreOffice attempts to create it.

For users running `unoconv` manually, this isn't a problem. 

For users attempting to run this on a webserver, the invoking user is the http daemon (e.g. `apache`, `nginx`, `lighttpd`), and the home folder is typically the webserver's root directory (e.g. `/srv/http`, `/var/www`).

Unfortunately, there appear to be some scenarios where this folder is read-only, even for the daemon (see #87, #449). This leads to errors, as Open/LibreOffice is unable to create its configuration folder.

(It is assumed that if the configuration folder already exists, it must be usable, else how would it have been created?)

This PR solves the issue by detecting this, emitting a warning message, and using a temporary folder as a temporary "Home".

----

An earlier version of this PR also added invocation arguments to permit a web-admin to specify an alternate location to be treated as "home". This functionality has been removed as it is better to set the `HOME` environment value before invoking `unoconv`.