### PR TITLE
Add python 3 support

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -14,6 +14,8 @@
 ### Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
 ### Copyright 2007-2010 Dag Wieers <dag@wieers.com>
 
+from __future__ import print_function
+
 from distutils.version import LooseVersion
 import getopt
 import glob
@@ -77,11 +79,11 @@ def find_offices():
     else:
 
         if os.name in ( 'nt', 'os2' ):
-            if 'PROGRAMFILES' in os.environ.keys():
+            if 'PROGRAMFILES' in list(os.environ.keys()):
                 extrapaths += glob.glob(os.environ['PROGRAMFILES']+'\\LibreOffice*') + \
                               glob.glob(os.environ['PROGRAMFILES']+'\\OpenOffice.org*')
 
-            if 'PROGRAMFILES(X86)' in os.environ.keys():
+            if 'PROGRAMFILES(X86)' in list(os.environ.keys()):
                 extrapaths += glob.glob(os.environ['PROGRAMFILES(X86)']+'\\LibreOffice*') + \
                               glob.glob(os.environ['PROGRAMFILES(X86)']+'\\OpenOffice.org*')
 
@@ -233,18 +235,18 @@ def office_environ(office):
 
 def debug_office():
     if 'URE_BOOTSTRAP' in os.environ:
-        print >>sys.stderr, 'URE_BOOTSTRAP=%s' % os.environ['URE_BOOTSTRAP']
+        print('URE_BOOTSTRAP=%s' % os.environ['URE_BOOTSTRAP'], file=sys.stderr)
     if 'UNO_PATH' in os.environ:
-        print >>sys.stderr, 'UNO_PATH=%s' % os.environ['UNO_PATH']
+        print('UNO_PATH=%s' % os.environ['UNO_PATH'], file=sys.stderr)
     if 'UNO_TYPES' in os.environ:
-        print >>sys.stderr, 'UNO_TYPES=%s' % os.environ['UNO_TYPES']
-    print 'PATH=%s' % os.environ['PATH']
+        print('UNO_TYPES=%s' % os.environ['UNO_TYPES'], file=sys.stderr)
+    print('PATH=%s' % os.environ['PATH'])
     if 'PYTHONHOME' in os.environ:
-        print >>sys.stderr, 'PYTHONHOME=%s' % os.environ['PYTHONHOME']
+        print('PYTHONHOME=%s' % os.environ['PYTHONHOME'], file=sys.stderr)
     if 'PYTHONPATH' in os.environ:
-        print >>sys.stderr, 'PYTHONPATH=%s' % os.environ['PYTHONPATH']
+        print('PYTHONPATH=%s' % os.environ['PYTHONPATH'], file=sys.stderr)
     if 'LD_LIBRARY_PATH' in os.environ:
-        print >>sys.stderr, 'LD_LIBRARY_PATH=%s' % os.environ['LD_LIBRARY_PATH']
+        print('LD_LIBRARY_PATH=%s' % os.environ['LD_LIBRARY_PATH'], file=sys.stderr)
 
 def python_switch(office):
     if office.pythonhome:
@@ -335,11 +337,11 @@ class FmtList:
         return ret
 
     def display(self, doctype):
-        print >>sys.stderr, "The following list of %s formats are currently available:\n" % doctype
+        print("The following list of %s formats are currently available:\n" % doctype, file=sys.stderr)
         for fmt in self.list:
             if fmt.doctype == doctype:
-                print >>sys.stderr, "  %-8s - %s" % (fmt.name, fmt)
-        print >>sys.stderr
+                print("  %-8s - %s" % (fmt.name, fmt), file=sys.stderr)
+        print(file=sys.stderr)
 
 fmts = FmtList()
 
@@ -530,14 +532,14 @@ class Options:
                  'outputpath', 'password=', 'pipe=', 'port=', 'server=',
                  'timeout=', 'show', 'stdout', 'template', 'verbose',
                  'version'] )
-        except getopt.error, exc:
-            print 'unoconv: %s, try unoconv -h for a list of all the options' % str(exc)
+        except getopt.error as exc:
+            print('unoconv: %s, try unoconv -h for a list of all the options' % str(exc))
             sys.exit(255)
 
         for opt, arg in opts:
             if opt in ['-h', '--help']:
                 self.usage()
-                print
+                print()
                 self.help()
                 sys.exit(1)
             elif opt in ['-c', '--connection']:
@@ -562,7 +564,7 @@ class Options:
                         except ValueError:
                             self.exportfilter.append( PropertyValue( name, 0, value, 0 ) )
                 else:
-                    print >>sys.stderr, 'Warning: Option %s cannot be parsed, ignoring.' % arg
+                    print('Warning: Option %s cannot be parsed, ignoring.' % arg, file=sys.stderr)
             elif opt in ['-f', '--format']:
                 self.format = arg
             elif opt in ['-i', '--import']:
@@ -581,7 +583,7 @@ class Options:
                         except ValueError:
                             self.importfilter.append( PropertyValue( name, 0, value, 0 ) )
                 else:
-                    print >>sys.stderr, 'Warning: Option %s cannot be parsed, ignoring.' % arg
+                    print('Warning: Option %s cannot be parsed, ignoring.' % arg, file=sys.stderr)
             elif opt in ['-l', '--listener']:
                 self.listener = True
             elif opt in ['-n', '--no-launch']:
@@ -589,7 +591,7 @@ class Options:
             elif opt in ['-o', '--output']:
                 self.output = arg
             elif opt in ['--outputpath']:
-                print >>sys.stderr, 'Warning: This option is deprecated by --output.'
+                print('Warning: This option is deprecated by --output.', file=sys.stderr)
                 self.output = arg
             elif opt in ['--password']:
                 self.password = arg
@@ -615,13 +617,13 @@ class Options:
 
         ### Enable verbosity
         if self.verbose >= 2:
-            print >>sys.stderr, 'Verbosity set to level %d' % self.verbose
+            print('Verbosity set to level %d' % self.verbose, file=sys.stderr)
 
         self.filenames = args
 
         if not self.listener and not self.showlist and self.doctype != 'list' and not self.filenames:
-            print >>sys.stderr, 'unoconv: you have to provide a filename as argument'
-            print >>sys.stderr, 'Try `unoconv -h\' for more information.'
+            print('unoconv: you have to provide a filename as argument', file=sys.stderr)
+            print('Try `unoconv -h\' for more information.', file=sys.stderr)
             sys.exit(255)
 
         ### Set connection string
@@ -659,21 +661,21 @@ class Options:
         ### Get office product information
         product = uno.getComponentContext().ServiceManager.createInstance("com.sun.star.configuration.ConfigurationProvider").createInstanceWithArguments("com.sun.star.configuration.ConfigurationAccess", UnoProps(nodepath="/org.openoffice.Setup/Product"))
 
-        print 'unoconv %s' % VERSION
-        print 'Written by Dag Wieers <dag@wieers.com>'
-        print 'Homepage at http://dag.wieers.com/home-made/unoconv/'
-        print
-        print 'platform %s/%s' % (os.name, sys.platform)
-        print 'python %s' % sys.version
-        print product.ooName, product.ooSetupVersion
+        print('unoconv %s' % VERSION)
+        print('Written by Dag Wieers <dag@wieers.com>')
+        print('Homepage at http://dag.wieers.com/home-made/unoconv/')
+        print()
+        print('platform %s/%s' % (os.name, sys.platform))
+        print('python %s' % sys.version)
+        print(product.ooName, product.ooSetupVersion)
 #        print
 #        print 'build revision $Rev$'
 
     def usage(self):
-        print >>sys.stderr, 'usage: unoconv [options] file [file2 ..]'
+        print('usage: unoconv [options] file [file2 ..]', file=sys.stderr)
 
     def help(self):
-        print >>sys.stderr, '''Convert from and to any format supported by LibreOffice
+        print('''Convert from and to any format supported by LibreOffice
 
 unoconv options:
   -c, --connection=string  use a custom connection string
@@ -698,7 +700,7 @@ unoconv options:
   -t, --template=file      import the styles from template (.ott)
   -T, --timeout=secs       timeout after secs if connection to listener fails
   -v, --verbose            be more and more verbose (-vvv for debugging)
-'''
+''', file=sys.stderr)
 
 class Convertor:
     def __init__(self):
@@ -714,7 +716,7 @@ class Convertor:
         info(3, 'Connection type: %s' % op.connection)
         try:
             unocontext = resolver.resolve("uno:%s" % op.connection)
-        except NoConnectException, e:
+        except NoConnectException as e:
 #            info(3, "Existing listener not found.\n%s" % e)
             info(3, "Existing listener not found.")
 
@@ -749,7 +751,7 @@ class Convertor:
                         raise
                 else:
                     error("Failed to connect to %s (pid=%s) in %d seconds.\n%s" % (office.binary, ooproc.pid, op.timeout, e))
-            except Exception, e:
+            except Exception as e:
                 raise
                 error("Launch of %s failed.\n%s" % (office.binary, e))
 
@@ -799,9 +801,9 @@ class Convertor:
         ### No format found, throw error
         if not outputfmt:
             if doctype:
-                print >>sys.stderr, 'unoconv: format [%s/%s] is not known to unoconv.' % (op.doctype, op.format)
+                print('unoconv: format [%s/%s] is not known to unoconv.' % (op.doctype, op.format), file=sys.stderr)
             else:
-                print >>sys.stderr, 'unoconv: format [%s] is not known to unoconv.' % op.format
+                print('unoconv: format [%s] is not known to unoconv.' % op.format, file=sys.stderr)
             die(1)
 
         return outputfmt
@@ -813,10 +815,10 @@ class Convertor:
         outputfmt = self.getformat(inputfn)
 
         if op.verbose > 0:
-            print >>sys.stderr, 'Input file:', inputfn
+            print('Input file:', inputfn, file=sys.stderr)
 
         if not os.path.exists(inputfn):
-            print >>sys.stderr, 'unoconv: file `%s\' does not exist.' % inputfn
+            print('unoconv: file `%s\' does not exist.' % inputfn, file=sys.stderr)
             exitcode = 1
 
         try:
@@ -854,7 +856,7 @@ class Convertor:
                     templateurl = unohelper.absolutize(self.cwd, unohelper.systemPathToFileUrl(op.template))
                     document.StyleFamilies.loadStylesFromURL(templateurl, templateprops)
                 else:
-                    print >>sys.stderr, 'unoconv: template file `%s\' does not exist.' % op.template
+                    print('unoconv: template file `%s\' does not exist.' % op.template, file=sys.stderr)
                     exitcode = 1
 
             ### Update document links
@@ -924,40 +926,40 @@ class Convertor:
 
             try:
                 document.storeToURL(outputurl, tuple(outputprops) )
-            except IOException, e:
+            except IOException as e:
                 raise UnoException("Unable to store document to %s (ErrCode %d)\n\nProperties: %s" % (outputurl, e.ErrCode, outputprops), None)
 
             phase = "dispose"
             document.dispose()
             document.close(True)
 
-        except SystemError, e:
+        except SystemError as e:
             error("unoconv: SystemError during %s phase:\n%s" % (phase, e))
             exitcode = 1
 
-        except RuntimeException, e:
+        except RuntimeException as e:
             error("unoconv: RuntimeException during %s phase:\nOffice probably died. %s" % (phase, e))
             exitcode = 6
 
-        except DisposedException, e:
+        except DisposedException as e:
             error("unoconv: DisposedException during %s phase:\nOffice probably died. %s" % (phase, e))
             exitcode = 7
 
-        except IllegalArgumentException, e:
+        except IllegalArgumentException as e:
             error("UNO IllegalArgument during %s phase:\nSource file cannot be read. %s" % (phase, e))
             exitcode = 8
 
-        except IOException, e:
+        except IOException as e:
 #            for attr in dir(e): print '%s: %s', (attr, getattr(e, attr))
             error("unoconv: IOException during %s phase:\n%s" % (phase, e.Message))
             exitcode = 3
 
-        except CannotConvertException, e:
+        except CannotConvertException as e:
 #            for attr in dir(e): print '%s: %s', (attr, getattr(e, attr))
             error("unoconv: CannotConvertException during %s phase:\n%s" % (phase, e.Message))
             exitcode = 4
 
-        except UnoException, e:
+        except UnoException as e:
             if hasattr(e, 'ErrCode'):
                 error("unoconv: UnoException during %s phase in %s (ErrCode %d)" % (phase, repr(e.__class__), e.ErrCode))
                 exitcode = e.ErrCode
@@ -982,7 +984,7 @@ class Listener:
             product = self.svcmgr.createInstance("com.sun.star.configuration.ConfigurationProvider").createInstanceWithArguments("com.sun.star.configuration.ConfigurationAccess", UnoProps(nodepath="/org.openoffice.Setup/Product"))
             try:
                 unocontext = resolver.resolve("uno:%s" % op.connection)
-            except NoConnectException, e:
+            except NoConnectException as e:
                 pass
             else:
                 info(1, "Existing %s listener found, nothing to do." % product.ooName)
@@ -991,25 +993,25 @@ class Listener:
                 subprocess.call([office.binary, "-headless", "-invisible", "-nocrashreport", "-nodefault", "-nologo", "-nofirststartwizard", "-norestore", "-accept=%s" % op.connection], env=os.environ)
             else:
                 subprocess.call([office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nologo", "--nofirststartwizard", "--norestore", "--accept=%s" % op.connection], env=os.environ)
-        except Exception, e:
+        except Exception as e:
             error("Launch of %s failed.\n%s" % (office.binary, e))
         else:
             info(1, "Existing %s listener found, nothing to do." % product.ooName)
 
 def error(msg):
     "Output error message"
-    print >>sys.stderr, msg
+    print(msg, file=sys.stderr)
 
 def info(level, msg):
     "Output info message"
     if 'op' not in globals():
         pass
     elif op.verbose >= 3 and level >= 3:
-        print >>sys.stderr, "DEBUG:", msg
+        print("DEBUG:", msg, file=sys.stderr)
     elif not op.stdout and level <= op.verbose:
-        print >>sys.stdout, msg
+        print(msg, file=sys.stdout)
     elif level <= op.verbose:
-        print >>sys.stderr, msg
+        print(msg, file=sys.stderr)
 
 def die(ret, msg=None):
     "Print optional error and exit with errorcode"
@@ -1031,7 +1033,7 @@ def die(ret, msg=None):
                     subprocess.Popen([office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nofirststartwizard", "--nologo", "--norestore", "--unaccept=%s" % op.connection], env=os.environ)
                 ooproc.wait()
                 info(2, '%s listener successfully disabled.' % product.ooName)
-            except Exception, e:
+            except Exception as e:
                 error("Terminate using %s failed.\n%s" % (office.binary, e))
 
         ### If there is no GUI attached to the instance, terminate instance
@@ -1080,7 +1082,7 @@ def main():
             for inputfn in op.filenames:
                 convertor.convert(inputfn)
 
-    except NoConnectException, e:
+    except NoConnectException as e:
         error("unoconv: could not find an existing connection to LibreOffice at %s:%s." % (op.server, op.port))
         if op.connection:
             info(0, "Please start an LibreOffice instance on server '%s' by doing:\n\n    unoconv --listener --server %s --port %s\n\nor alternatively:\n\n    soffice -nologo -nodefault -accept=\"%s\"" % (op.server, op.server, op.port, op.connection))
@@ -1110,14 +1112,14 @@ if __name__ == '__main__':
             break
         except:
 #            debug_office()
-            print >>sys.stderr, "unoconv: Cannot find a suitable pyuno library and python binary combination in %s" % of
-            print >>sys.stderr, "ERROR:", sys.exc_info()[1]
-            print >>sys.stderr
+            print("unoconv: Cannot find a suitable pyuno library and python binary combination in %s" % of, file=sys.stderr)
+            print("ERROR:", sys.exc_info()[1], file=sys.stderr)
+            print(file=sys.stderr)
     else:
 #        debug_office()
-        print >>sys.stderr, "unoconv: Cannot find a suitable office installation on your system."
-        print >>sys.stderr, "ERROR: Please locate your office installation and send your feedback to:"
-        print >>sys.stderr, "       http://github.com/dagwieers/unoconv/issues"
+        print("unoconv: Cannot find a suitable office installation on your system.", file=sys.stderr)
+        print("ERROR: Please locate your office installation and send your feedback to:", file=sys.stderr)
+        print("       http://github.com/dagwieers/unoconv/issues", file=sys.stderr)
         sys.exit(1)
 
     ### Now that we have found a working pyuno library, let's import some classes
@@ -1160,6 +1162,6 @@ if __name__ == '__main__':
 
     try:
         main()
-    except KeyboardInterrupt, e:
+    except KeyboardInterrupt as e:
         die(6, 'Exiting on user request')
     die(exitcode)


### PR DESCRIPTION
Libreoffice 4.0 will switch its internal python version to 3.3.0
so it's the right time to support that.

Porting done automatically using 2to3 plus print_function import added
manually. Tested on both libreoffice master with internal python
and with libreoffice 3.6.4 on debian with system python 2.7.

This bumps the minimal python version to 2.6 since 2.5 does not
have the print function. Testing on more environments appreciated.
