### PR TITLE
Fix documentation typos

### DIFF
--- a/doc/filters.txt
+++ b/doc/filters.txt
@@ -101,7 +101,7 @@ the window (cuts out margins) *4*:means with a zoom level given in the â€œZoomâ€
 property.
 |MaxImageResolution        |integer|300     |If the property
 If the property ReduceImageResolution is set to true all images will be reduced
-to the given value in DPI. Posible values: *75*, *150*, *300*, *600*, *1200*
+to the given value in DPI. Possible values: *75*, *150*, *300*, *600*, *1200*
 |OpenBookmarkLevels        |integer|-1      |Specifies how many bookmark
 levels should be opened in the reader application when the PDF gets opened. -1
 means all levels, non-negative numbers mean the respective number of levels.

--- a/doc/unoconv.1
+++ b/doc/unoconv.1
@@ -222,7 +222,7 @@ The default import filter for many imports (eg\&. Lotus, dBase or DIF) accepts a
 .RE
 .\}
 .sp
-For a list of posible encoding types, you can use the above link to find the possible options\&.
+For a list of possible encoding types, you can use the above link to find the possible options\&.
 .sp
 .RS 4
 .ie n \{\
@@ -278,7 +278,7 @@ If you like to use more than one separator (say a space or a tab) and use the sy
 .RE
 .\}
 .sp
-For a list of posible encoding types, you can use the above link to find the possible options\&.
+For a list of possible encoding types, you can use the above link to find the possible options\&.
 .sp
 .RS 4
 .ie n \{\
@@ -339,7 +339,7 @@ If you like to use more than one separator (say a space or a tab) and use the sy
 .RE
 .\}
 .sp
-For a list of posible encoding types, you can use the above link to find the possible options\&.
+For a list of possible encoding types, you can use the above link to find the possible options\&.
 .sp
 .RS 4
 .ie n \{\

--- a/doc/unoconv.1.txt
+++ b/doc/unoconv.1.txt
@@ -134,7 +134,7 @@ you can do:
 
     -i FilterOptions=76
 
-For a list of posible encoding types, you can use the above link to find the
+For a list of possible encoding types, you can use the above link to find the
 possible options.
 
   - FilterOptions
@@ -165,7 +165,7 @@ system's encoding (9), but with no text-delimiter, you can do:
 
     -i FilterOptions=9/32,,9,2
 
-For a list of posible encoding types, you can use the above link to find the
+For a list of possible encoding types, you can use the above link to find the
 possible options.
 
   - FilterOptions
@@ -207,7 +207,7 @@ system's encoding (9), but with no text-delimiter, you can do:
 
     -e FilterOptions=9/32,,9
 
-For a list of posible encoding types, you can use the above link to find the
+For a list of possible encoding types, you can use the above link to find the
 possible options.
 
   - FilterOptions


### PR DESCRIPTION
Credit to Vincent Bernat for fixing an instance in the debian package of unoconv 0.5 - I just found more instances and am forwarding the fix.
