### PR TITLE
#133 fix export to non existent directory

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -915,12 +915,10 @@ class Convertor:
                 (outputfn, ext) = os.path.splitext(inputfn)
                 if not op.output:
                     outputfn = outputfn + os.extsep + outputfmt.extension
-                elif os.path.isdir(op.output):
-                    outputfn = realpath(op.output, os.path.basename(outputfn) + os.extsep + outputfmt.extension)
                 elif len(op.filenames) > 1:
                     outputfn = op.output + os.extsep + outputfmt.extension
                 else:
-                    outputfn = op.output
+                    outputfn = realpath(op.output, os.path.basename(outputfn) + os.extsep + outputfmt.extension)
 
                 outputurl = unohelper.absolutize( self.cwd, unohelper.systemPathToFileUrl(outputfn) )
                 info(1, "Output file: %s" % outputfn)


### PR DESCRIPTION
Code I used to fix this issue:

https://github.com/dagwieers/unoconv/issues/133

One thing that I noticed is the trailing slash is now essential for exporting to folders, where it wasn't needed in 0.4.
