### PR TITLE
if run in a virtualenv and cannot find pyuno at startup, show reminder a...

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -1100,6 +1100,13 @@ def main():
     except OSError:
         error("Warning: failed to launch Office suite. Aborting.")
 
+def is_virtualenv():
+    try:
+        sys.real_prefix
+    except AttributeError:
+        return False
+    return True
+
 ### Main entrance
 if __name__ == '__main__':
     exitcode = 0
@@ -1115,11 +1122,19 @@ if __name__ == '__main__':
             import uno, unohelper
             office = of
             break
-        except:
+        except Exception as e:
 #            debug_office()
             print("unoconv: Cannot find a suitable pyuno library and python binary combination in %s" % of, file=sys.stderr)
             print("ERROR:", sys.exc_info()[1], file=sys.stderr)
             print(file=sys.stderr)
+
+            if isinstance(e, ImportError) and is_virtualenv():
+                print("-"*80, file=sys.stderr)
+                print("unoconv: It looks like unoconv is run in a virtualenv.", file=sys.stderr)
+                print("         Make sure uno.py and unohelper.py files are available in this \n"
+                      "         virtualenv site-packages directory.", file=sys.stderr)
+                print("-"*80, file=sys.stderr)
+
     else:
 #        debug_office()
         print("unoconv: Cannot find a suitable office installation on your system.", file=sys.stderr)


### PR DESCRIPTION
...bout uno.py/unohelper.py presence in virtualenv site-packages dir
- by default virtualenv isolates from system site-packages
- uno.py / unohelper.py from package python-uno are in /usr/share/pyshared and thus not available in virtualenv

This purpose of this patch is to help user with a possible fix when unoconv can't start in a virtualenv
