### PR TITLE
fix stdout option for python 2 and 3, add option for remote input url

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -698,6 +698,7 @@ unoconv options:
   -p, --port=port          specify the port (default: 2002)
                              to be used by client or listener
       --password=string    provide a password to decrypt the document
+  -r, --remote             use with remote input url (http://example.com/file.docx)
   -s, --server=server      specify the server address (default: 127.0.0.1)
                              to be used by client or listener
       --show               list the available output formats


### PR DESCRIPTION
This adds support for remote urls and conditionally writes to stdout buffer for python 3
