### PR TITLE
fix stdout option for python 2 and 3, add option for remote url

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -841,19 +841,19 @@ class Convertor:
 
             ### Cannot use UnoProps for FilterData property
             if op.importfilteroptions:
-		inputprops += UnoProps(FilterOptions=op.importfilteropti
+                inputprops += UnoProps(FilterOptions=op.importfilteroptions)
 
             ### Cannot use UnoProps for FilterData property
             if op.importfilter:
                 inputprops += ( PropertyValue( "FilterData", 0, uno.Any("[]com.sun.star.beans.PropertyValue", tuple( op.importfilter ), ), 0 ), )
 
-	    if op.remote:
+            if op.remote:
                 document = self.desktop.loadComponentFromURL( inputfn , "_blank", 0, inputprops )
 
-	    if op.stdin:
-		inputStream = self.svcmgr.createInstanceWithContext("com.sun.star.io.SequenceInputStream", self.context)
-		inputStream.initialize((uno.ByteSequence(sys.stdin.read()),))
-		document = self.desktop.loadComponentFromURL('private:stream', "_blank", 0, UnoProps(InputStream=inputStream, ReadOnly=True, Hidden=True))
+            if op.stdin:
+                inputStream = self.svcmgr.createInstanceWithContext("com.sun.star.io.SequenceInputStream", self.context)
+                inputStream.initialize((uno.ByteSequence(sys.stdin.read()),))
+                document = self.desktop.loadComponentFromURL('private:stream', "_blank", 0, UnoProps(InputStream=inputStream, ReadOnly=True, Hidden=True))
             else:
                 inputurl = unohelper.absolutize(self.cwd, unohelper.systemPathToFileUrl(inputfn))
                 document = self.desktop.loadComponentFromURL( inputurl , "_blank", 0, inputprops )


### PR DESCRIPTION
adds ability to convert files with remote input url, 
checks python version before writing to stdout and uses buffered write for python 3 and direct write for earlier versions,
adds stdin option using private:stream

```
root@app0:~# unoconv --version
unoconv 0.6
Written by Dag Wieers <dag@wieers.com>
Homepage at http://dag.wieers.com/home-made/unoconv/

platform posix/linux2
python 2.7.3 (default, Feb 27 2014, 20:00:17)
[GCC 4.6.3]
LibreOffice 4.2
```

```
root@app0:~# unoconv -r --stdout -f html http://fqdn.com/sample.docx
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
<html>
<head>
...
```
