### PR TITLE
Add -U / --user-installation switch to specify where the LibreOffice profile should be

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -510,6 +510,7 @@ class Options:
         self.connection = None
         self.debug = False
         self.doctype = None
+        self.userinstallation = None
         self.exportfilter = []
         self.exportfilteroptions = ""
         self.fields = {}
@@ -540,12 +541,12 @@ class Options:
 
         ### Get options from the commandline
         try:
-            opts, args = getopt.getopt (args, 'c:Dd:e:F:f:hi:LlM:no:p:s:T:t:P:vV',
+            opts, args = getopt.getopt (args, 'c:Dd:e:F:f:hi:LlM:no:p:s:T:t:U:P:vV',
                 ['connection=', 'debug', 'doctype=', 'export=', 'field=', 'format=',
                  'help', 'import=', 'listener', 'meta=', 'no-launch', 'output=',
                  'outputpath', 'password=', 'pipe=', 'port=', 'preserve',
                  'server=', 'timeout=', 'show', 'stdin', 'stdout', 'template', 'printer=',
-                 'verbose', 'version'] )
+                 'userinstallation=', 'verbose', 'version'] )
         except getopt.error as exc:
             print('unoconv: %s, try unoconv -h for a list of all the options' % str(exc))
             sys.exit(255)
@@ -633,6 +634,8 @@ class Options:
                 self.template = arg
             elif opt in ['-T', '--timeout']:
                 self.timeout = int(arg)
+            elif opt in ['-U', '--userinstallation']:
+                self.userinstallation = arg
             elif opt in ['-v', '--verbose']:
                 self.verbose = self.verbose + 1
             elif opt in ['-V', '--version']:
@@ -744,6 +747,7 @@ unoconv options:
       --stdout                        write output to stdout
   -t, --template=file                 import the styles from template (.ott)
   -T, --timeout=secs                  timeout after secs if connection to listener fails
+  -U, --userinstallation=value             set the userinstallation to start the listener in
   -v, --verbose                       be more and more verbose (-vvv for debugging)
       --version                       display version number of unoconv, OOo/LO and platform details
   -P, --printer                       printer options
@@ -803,7 +807,12 @@ class Convertor:
                 if product.ooName not in ('LibreOffice', 'LOdev') or LooseVersion(product.ooSetupVersion) <= LooseVersion('3.3'):
                     ooproc = subprocess.Popen([office.binary, "-headless", "-invisible", "-nocrashreport", "-nodefault", "-nofirststartwizard", "-nologo", "-norestore", "-accept=%s" % op.connection], env=os.environ)
                 else:
-                    ooproc = subprocess.Popen([office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nofirststartwizard", "--nologo", "--norestore", "--accept=%s" % op.connection], env=os.environ)
+                    argv = [office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nofirststartwizard", "--nologo", "--norestore", "--accept=%s" % op.connection]
+
+                    if op.userinstallation:
+                        argv.append("-env:UserInstallation=file://" + op.userinstallation)
+
+                    ooproc = subprocess.Popen(argv, env=os.environ)
                 info(2, '%s listener successfully started. (pid=%s)' % (product.ooName, ooproc.pid))
 
                 ### Try connection to it for op.timeout seconds (flakky OpenOffice)
@@ -1154,7 +1163,12 @@ class Listener:
             if product.ooName != "LibreOffice" or LooseVersion(product.ooSetupVersion) <= LooseVersion('3.3'):
                 office_process = subprocess.Popen([office.binary, "-headless", "-invisible", "-nocrashreport", "-nodefault", "-nologo", "-nofirststartwizard", "-norestore", "-accept=%s" % op.connection], env=os.environ)
             else:
-                office_process = subprocess.Popen([office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nologo", "--nofirststartwizard", "--norestore", "--accept=%s" % op.connection], env=os.environ)
+                argv = [office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nologo", "--nofirststartwizard", "--norestore", "--accept=%s" % op.connection]
+
+                if op.userinstallation:
+                    argv.append("-env:UserInstallation=file://" + op.userinstallation)
+
+                office_process = subprocess.Popen(argv, env=os.environ)
 
             # The rationale for using subprocess.Popen is to be able to handle
             # a SIGTERM signal below and properly terminate the started office
@@ -1208,7 +1222,12 @@ def die(ret, msg=None):
                 if product.ooName != "LibreOffice" or product.ooSetupVersion <= 3.3:
                     subprocess.Popen([office.binary, "-headless", "-invisible", "-nocrashreport", "-nodefault", "-nofirststartwizard", "-nologo", "-norestore", "-unaccept=%s" % op.connection], env=os.environ)
                 else:
-                    subprocess.Popen([office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nofirststartwizard", "--nologo", "--norestore", "--unaccept=%s" % op.connection], env=os.environ)
+                    argv = [office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nofirststartwizard", "--nologo", "--norestore", "--unaccept=%s" % op.connection]
+
+                    if op.userinstallation:
+                        argv.append("-env:UserInstallation=file://" + op.userinstallation)
+
+                    subprocess.Popen(argv, env=os.environ)
                 ooproc.wait()
                 info(2, '%s listener successfully disabled.' % product.ooName)
             except Exception as e:


### PR DESCRIPTION
(Note this is recreated from PR #190 but updated for the latest version of unoconv)

It seems that the way to allow for multiple parallel instances of unoconv is to have each instance [set its own value for `env:UserInstallation`](http://ask.libreoffice.org/en/question/14841/how-can-i-use-soffice-from-the-command-line-when-quickstarter-is-running/?answer=29735#post-id-29735), which `soffice` takes as a parameter on initialization (setting a different port per listener is most likely required too, but that's already available).

This PR adds an `-U` / `--user-installation` switch to set this variable. 

I don't really have python experience, so I apologize if there is a better way to code this (I'm a ruby programmer :smile:). 
