### PR TITLE
Support LibreOffice 5.4.6.2 on Mac OS X 10.13.3 with case-sensitive filesystem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,21 @@ env:
   - VERSION=5.2.7.2
   - VERSION=5.3.7.2
   - VERSION=5.4.3.2
+  - VERSION=5.4.6.2
 
 language: generic
 
-# On macOS, only test the oldest and newest version. If they work, reasonably
-# everything else does as well. We do this because Travis macOS testing is
-# painfully slow.
+# On Mac OS X, only test selected versions (the oldest and a few recent versions).
+# If they work, reasonably everything else does as well.
+# We do this because testing Mac OS X on Travis is painfully slow.
 matrix:
   include:
     - os: osx
       env: VERSION=4.2.8.2
     - os: osx
       env: VERSION=5.4.3.2
+    - os: osx
+      env: VERSION=5.4.6.2
   exclude:
     - os: osx
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+* in progress
+- Support LibreOffice 5.x.x.x on recent Mac OS X systems with case-sensitive filesystem
+
 * 0.8.2 - released 2017-12-07
 - Fixed PyPI upload
 

--- a/unoconv
+++ b/unoconv
@@ -197,23 +197,44 @@ def find_offices():
 #        if not glob.glob(realpath(basepath, basis, program, 'python-core-*')):
 #            continue
 
-        for pythonbinary in pythonbinaries:
-            if os.path.isfile(realpath(unopath, pythonbinary)):
-                info(3, "Found %s in %s" % (pythonbinary, unopath))
-                ret.append(Office(basepath, urepath, unopath, officelibrary, officebinary,
-                                  realpath(unopath, pythonbinary), pythonhome))
+        ### Find suitable Python executable
+        pythonpath_candidates = [
+            # Regular unopath
+            unopath,
+            # LibreOffice 5.4.6.2 on Mac OS X 10.13.3 ships
+            # the "python" executable in the "Resources" folder.
+            realpath(basepath, 'Resources'),
+        ]
+
+        python_effective = find_executable(pythonpath_candidates, pythonbinaries)
+
+        if python_effective:
+            info(3, "Found Python at %s" % python_effective)
+            office = Office(basepath, urepath, unopath, officelibrary, officebinary,
+                            python_effective, pythonhome)
         else:
             info(3, "Considering %s" % basepath)
-            ret.append(Office(basepath, urepath, unopath, officelibrary, officebinary,
-                              sys.executable, None))
+            office = Office(basepath, urepath, unopath, officelibrary, officebinary,
+                            sys.executable, None)
+
+        ret.append(office)
+
     return ret
+
+def find_executable(folders, filenames):
+    for folder in folders:
+        for filename in filenames:
+            candidate = realpath(folder, filename)
+            if os.path.isfile(candidate):
+                return candidate
 
 def office_environ(office):
     ### Set PATH so that crash_report is found
+    path_prefix = realpath(office.basepath, 'program') + os.pathsep + realpath(office.basepath, 'Resources')
     if 'PATH' in os.environ:
-        os.environ['PATH'] = realpath(office.basepath, 'program') + os.pathsep + os.environ['PATH']
+        os.environ['PATH'] = path_prefix + os.pathsep + os.environ['PATH']
     else:
-        os.environ['PATH'] = realpath(office.basepath, 'program') + os.pathsep + realpath(office.basepath, 'resources')
+        os.environ['PATH'] = path_prefix
 
     ### Set UNO_PATH so that "officehelper.bootstrap()" can find soffice executable:
     os.environ['UNO_PATH'] = office.unopath
@@ -226,7 +247,7 @@ def office_environ(office):
         if os.path.isfile(realpath(office.basepath, 'program', 'fundamentalrc')):
             os.environ['URE_BOOTSTRAP'] = 'vnd.sun.star.pathname:' + realpath(office.basepath, 'program', 'fundamentalrc')
         else:
-            os.environ['URE_BOOTSTRAP'] = 'vnd.sun.star.pathname:' + realpath(office.basepath, 'resources', 'fundamentalrc')
+            os.environ['URE_BOOTSTRAP'] = 'vnd.sun.star.pathname:' + realpath(office.basepath, 'Resources', 'fundamentalrc')
 
         ### Set LD_LIBRARY_PATH so that "import pyuno" finds libpyuno.so:
         if 'LD_LIBRARY_PATH' in os.environ:
@@ -308,6 +329,8 @@ def python_switch(office):
             ### appear to be consistent, so we can't easily check for
             ### this error specifically.
             ret = os.spawnvpe(os.P_WAIT, office.python, [office.python, ] + sys.argv[0:], os.environ)
+            if ret != 0:
+                error("Switching Python to %s failed." % (office.python))
             sys.exit(ret)
 
 class Fmt:


### PR DESCRIPTION
Hi there,

first things first: Thanks for conceiving and maintaining `unoconv`, it saves us a lot of troubles when talking to LibreOffice and is a real pleasure to use.

This PR improves the situation regarding appropriately finding the LibreOffice assets along the lines of #27, #49, #263, #391 and #442. We are running LibreOffice 5.4.6.2 on Mac OS X 10.13.3 with a case-sensitive filesystem, `unoconv` was installed using `brew install unoconv`.

These amendments account for:
- Use `/Applications/LibreOffice.app/Contents/Resources/python` as yet another candidate for finding the `python` executable shipped with LibreOffice on Mac OS X
- Support case-sensitive filesystems on Mac OS X re. capitalized notation of the `Resources` folder
- Fix manipulation of `os.environ['PATH']`
- Report error if `os.spawnvpe()` fails

We hope you like this.

With kind regards,
Andreas.