### PR TITLE
Consider only the basename for ‘foo2bar’ aliases

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -740,7 +740,7 @@ class Options:
         ### If no format was specified, probe it or provide it
         if not self.format:
             ### Check if the command is in the form odt2pdf
-            l = sys.argv[0].split('2')
+            l = os.path.basename(sys.argv[0]).split('2')
             if len(l) == 2:
                 self.format = l[1]
             ### Use the extension of the output file


### PR DESCRIPTION
Previously, running unoconv from any location with exactly one ‘2’ in it
would fail.  This is a real problem on GNU Guix, where each package
directory is prefixed with an alphanumeric hash.

  $ …/a2b/unoconv <file>
  unoconv: format [b/unoconv] is not known to unoconv.