### PR TITLE
Fix distutils deprecation

### DIFF
--- a/unoconv
+++ b/unoconv
@@ -16,7 +16,7 @@
 
 from __future__ import print_function
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 import getopt
 import glob
 import os
@@ -867,7 +867,7 @@ class Convertor:
             info(3, "Launching our own listener using %s." % office.binary)
             try:
                 product = self.svcmgr.createInstance("com.sun.star.configuration.ConfigurationProvider").createInstanceWithArguments("com.sun.star.configuration.ConfigurationAccess", UnoProps(nodepath="/org.openoffice.Setup/Product"))
-                if product.ooName not in ('LibreOffice', 'LOdev') or LooseVersion(product.ooSetupVersion) <= LooseVersion('3.3'):
+                if product.ooName not in ('LibreOffice', 'LOdev') or Version(product.ooSetupVersion) <= Version('3.3'):
                     args = [office.binary, "-headless", "-invisible", "-nocrashreport", "-nodefault", "-nofirststartwizard", "-nologo", "-norestore", "-accept=%s" % op.connection]
                 else:
                     args = [office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nofirststartwizard", "--nologo", "--norestore", "--accept=%s" % op.connection]
@@ -1235,7 +1235,7 @@ class Listener:
             else:
                 info(1, "Existing %s listener found, nothing to do." % product.ooName)
                 return
-            if product.ooName != "LibreOffice" or LooseVersion(product.ooSetupVersion) <= LooseVersion('3.3'):
+            if product.ooName != "LibreOffice" or Version(product.ooSetupVersion) <= Version('3.3'):
                 cmd = [office.binary, "-headless", "-invisible", "-nocrashreport", "-nodefault", "-nologo", "-nofirststartwizard", "-norestore", "-accept=%s" % op.connection]
             else:
                 cmd = [office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nologo", "--nofirststartwizard", "--norestore", "--accept=%s" % op.connection]

--- a/unoconv
+++ b/unoconv
@@ -16,7 +16,6 @@
 
 from __future__ import print_function
 
-from packaging.version import Version
 import getopt
 import glob
 import os
@@ -25,7 +24,7 @@ import subprocess
 import sys
 import time
 
-__version__ = '0.8.2'
+__version__ = '0.8.3'
 
 doctypes = ('document', 'graphics', 'presentation', 'spreadsheet')
 
@@ -62,6 +61,22 @@ def realpath(*args):
         ret = os.path.join(ret, arg)
     return os.path.realpath(os.path.abspath(ret))
 
+def cmp_versions(a, b):
+    a_parts = a.split(".")
+    b_parts = b.split(".")
+    l = min(len(a_parts), len(b_parts))
+
+    for i in range(l):
+        d = int(a_parts[i]) - int(b_parts[i])
+        if d != 0:
+            return d
+
+    return len(a_parts) - len(b_parts)
+
+# Example usage:
+# print(cmp_versions("1.2.3", "1.2.4"))  # Output: -1
+# print(cmp_versions("1.2.3", "1.2.3"))  # Output: 0
+# print(cmp_versions("1.2.3", "1.2"))    # Output: 1
 
 # The first thing we should do is find a suitable Office installation
 # with a compatible pyuno library that we can import.
@@ -867,7 +882,7 @@ class Convertor:
             info(3, "Launching our own listener using %s." % office.binary)
             try:
                 product = self.svcmgr.createInstance("com.sun.star.configuration.ConfigurationProvider").createInstanceWithArguments("com.sun.star.configuration.ConfigurationAccess", UnoProps(nodepath="/org.openoffice.Setup/Product"))
-                if product.ooName not in ('LibreOffice', 'LOdev') or Version(product.ooSetupVersion) <= Version('3.3'):
+                if product.ooName not in ('LibreOffice', 'LOdev') or (cmp_versions(product.ooSetupVersion, '3.3') <= 0):
                     args = [office.binary, "-headless", "-invisible", "-nocrashreport", "-nodefault", "-nofirststartwizard", "-nologo", "-norestore", "-accept=%s" % op.connection]
                 else:
                     args = [office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nofirststartwizard", "--nologo", "--norestore", "--accept=%s" % op.connection]
@@ -1235,7 +1250,7 @@ class Listener:
             else:
                 info(1, "Existing %s listener found, nothing to do." % product.ooName)
                 return
-            if product.ooName != "LibreOffice" or Version(product.ooSetupVersion) <= Version('3.3'):
+            if product.ooName != "LibreOffice" or (cmp_versions(product.ooSetupVersion, '3.3') <= 0):
                 cmd = [office.binary, "-headless", "-invisible", "-nocrashreport", "-nodefault", "-nologo", "-nofirststartwizard", "-norestore", "-accept=%s" % op.connection]
             else:
                 cmd = [office.binary, "--headless", "--invisible", "--nocrashreport", "--nodefault", "--nologo", "--nofirststartwizard", "--norestore", "--accept=%s" % op.connection]


### PR DESCRIPTION
Python 3.10 deprecates distutils, and advises to use setuptools or packaging instead. Distutils will be removed in 3.12, which will cause unoconv to fail.

The suggested path is not a feasible one for a Python script run with the current LibreOffice Python, since this does not include setuptools or packaging, or even pip. And even if it did, using unoconv with older versions should not be hampered by the change.

So this change includes a custom, very simple, comparator instead of a module-provided and arguably better one.

Since I cannot find any evidence of letters being used in LO's versioning schemes (old or new), I think/hope the comparator should do the trick just fine.

NOTE that it is being used in a test to check whether we're not using 'LibreOffice' as such, or whether the version is as old as 3.3 or below. Pretty old.